### PR TITLE
whitelist renamed to allowlist in bindgen

### DIFF
--- a/bin/generate.sh
+++ b/bin/generate.sh
@@ -7,7 +7,7 @@ set -eux
 #
 # * By default, `char` is converted to `::std::os::raw::c_char`. However, to
 #   preserve no_std, it is truncated to `c_char` and gets taken from `libc`.
-bindgen --whitelist-function='^.*_$' --use-core bin/wrapper.h \
+bindgen --allowlist-function='^.*_$' --use-core bin/wrapper.h \
   | sed -e 's/::std::os::raw:://g' \
   | sed -e '/__darwin_size_t/d' \
   > src/lapack.rs


### PR DESCRIPTION
The `--whitelist-function` argument to `bindgen` has been renamed to `--allowlist-function`, see https://github.com/rust-lang/rust-bindgen/pull/1990.